### PR TITLE
fix outdated callsite of fastx_reader when feature!="gz"

### DIFF
--- a/src/fastx.rs
+++ b/src/fastx.rs
@@ -320,7 +320,7 @@ pub fn fastx_file<F>(filename: &str, ref mut callback: F) -> Result<(), ParseErr
     //! Parse a file (given its name) into FASTX records and calls `callback` on each.
     let mut f = File::open(&Path::new(filename))?;
 
-    fastx_reader(&mut f, callback, None::<&mut FnMut(&'static str) -> ()>)
+    fastx_reader(&mut f, None, callback, None::<&mut FnMut(&'static str) -> ()>)
 }
 
 


### PR DESCRIPTION
Seems you added the "first byte" parameter to `fastx_reader`, but the refactoring didn't pick up this usage, because it is `cfg`'d out by default.

(IntelliJ-rust highlighted this for me.)