### PR TITLE
Fix compilation without default features, and add CI job to check it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,11 +69,20 @@ jobs:
     steps:
       - checkout_and_setup
       - run:
-          name: Run all tests
+          name: Run all tests (without default features)
           command: cargo test --all --no-default-features
       - run:
-          name: Run slow tests
+          name: Run slow tests (without default features)
           command: cargo test --no-default-features -- --ignored
+  build-on-wasm-target:
+    executor: needletail
+    steps:
+      - checkout_and_setup
+      - run:
+          name: Build on wasm32-unknown-unknown
+          command: |
+            rustup target add wasm32-unknown-unknown
+            cargo build --all --no-default-features --target wasm32-unknown-unknown
   lint:
     executor: needletail
     steps:
@@ -138,6 +147,9 @@ workflows:
   ci-checks:
     jobs:
       - build
+      - build-on-wasm-target:
+          requires:
+            - build
       - coverage:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,16 @@ jobs:
       - run:
           name: Run slow tests
           command: cargo test -- --ignored
+  test-without-default-features:
+    executor: needletail
+    steps:
+      - checkout_and_setup
+      - run:
+          name: Run all tests
+          command: cargo test --all --no-default-features
+      - run:
+          name: Run slow tests
+          command: cargo test --no-default-features -- --ignored
   lint:
     executor: needletail
     steps:
@@ -132,6 +142,9 @@ workflows:
           requires:
             - build
       - test:
+          requires:
+            - build
+      - test-without-default-features:
           requires:
             - build
       - lint:

--- a/src/bitkmer.rs
+++ b/src/bitkmer.rs
@@ -274,5 +274,4 @@ mod tests {
         }
         bit_kmer
     }
-
 }

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -120,7 +120,7 @@ where
     //! that gets called as soon as we determine if the records are FASTA or FASTQ.
     let mut first = vec![0, 0];
     reader.read_exact(&mut first)?;
-    seq_reader(&mut reader, callback, &mut type_callback, &first)
+    seq_reader(&mut reader, callback, &mut type_callback, first)
 }
 
 #[cfg(feature = "compression")]

--- a/src/util.rs
+++ b/src/util.rs
@@ -141,5 +141,4 @@ mod tests {
         let pos = memchr_both_last(b'\n', b'-', &b"-te\nst\n-this"[..]);
         assert_eq!(pos, Some(6));
     }
-
 }


### PR DESCRIPTION
Hi!

I was trying out adding needletail to a project and using the `wasm32-unknown-unknown` target, but for that I had to disable the `compression` feature (which is also default). I ended up finding an error, and seems like CI wasn't checking for this case, so I also added another job.

Oh: is it OK to add another CI job, for checking compilation for `wasm32-unknown-unknown` target? It is enough to just run `cargo build --target wasm32-unknown-unknown` (and add the target with `rustup`), but I think it gets messier to add to an existing job than to create a new one.

UPDATE: the wasm32 CI job is now in https://github.com/onecodex/needletail/pull/37/commits/07743c8406f9c9028a7dd65bb464072a5a311b7a, but I can remove it from the PR if that's not desirable.