### PR TITLE
Drop Seek bound, and add back stdin support and parsing from a Reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ bench = false
 
 [features]
 default = ["compression"]
-compression = ["niffler/bz2", "niffler/lzma"]
+compression = ["niffler/bz2", "niffler/lzma", "niffler/gz"]
 python = ["pyo3/extension-module"]
 python_test = ["pyo3"]
 
 [dependencies]
-niffler = { version = "2.1.1", default_features = false }
+niffler = { version = "2.2.0", default_features = false }
 pyo3 = { version = "0.10", optional = true }
 memchr = "2.2.1"
 bytecount = {version = "0.6", features = ["runtime-dispatch-simd"]}
@@ -30,6 +30,10 @@ buf_redux = { version = "0.8", default_features = false }
 
 [dev-dependencies]
 criterion = "0.3"
+escargot = "0.5.0"
+assert_cmd = "1.0.1"
+predicates = "1.0.4"
+tempfile = "3"
 
 # for benchmark comparisons
 bio = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,12 @@ bench = false
 
 [features]
 default = ["compression"]
-compression = []
+compression = ["niffler/bz2", "niffler/lzma"]
 python = ["pyo3/extension-module"]
 python_test = ["pyo3"]
 
 [dependencies]
-# TODO: figure out the compression feature from needletail, and how to set it in niffler
-niffler = { version = "2.1.0", features = ["bz2", "lzma"] }
+niffler = { version = "2.1.0", default_features = false }
 pyo3 = { version = "0.10", optional = true }
 memchr = "2.2.1"
 bytecount = {version = "0.6", features = ["runtime-dispatch-simd"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ python = ["pyo3/extension-module"]
 python_test = ["pyo3"]
 
 [dependencies]
-niffler = { version = "2.1.0", default_features = false }
+niffler = { version = "2.1.1", default_features = false }
 pyo3 = { version = "0.10", optional = true }
 memchr = "2.2.1"
 bytecount = {version = "0.6", features = ["runtime-dispatch-simd"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,13 @@ bench = false
 
 [features]
 default = ["compression"]
-compression = ["bzip2", "flate2", "xz2"]
+compression = []
 python = ["pyo3/extension-module"]
 python_test = ["pyo3"]
 
 [dependencies]
-flate2 = { version="1.0.6", optional=true }
-bzip2 = { version="0.3.3", optional=true }
-xz2 = { version="0.1.6", optional=true }
+# TODO: figure out the compression feature from needletail, and how to set it in niffler
+niffler = { version = "2.1.0", features = ["bz2", "lzma"] }
 pyo3 = { version = "0.10", optional = true }
 memchr = "2.2.1"
 bytecount = {version = "0.6", features = ["runtime-dispatch-simd"]}

--- a/examples/stdin_pipe.rs
+++ b/examples/stdin_pipe.rs
@@ -1,0 +1,32 @@
+use needletail::{parse_fastx_file, Sequence};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut n_bases = 0;
+    let mut n_valid_kmers = 0;
+    let mut reader = parse_fastx_file("-").expect("valid path/file");
+    while let Some(record) = reader.next() {
+        let seqrec = record.expect("invalid record");
+        // keep track of the total number of bases
+        n_bases += seqrec.num_bases();
+        // normalize to make sure all the bases are consistently capitalized and
+        // that we remove the newlines since this is FASTA
+        let norm_seq = seqrec.normalize(false);
+        // we make a reverse complemented copy of the sequence first for
+        // `canonical_kmers` to draw the complemented sequences from.
+        let rc = norm_seq.reverse_complement();
+        // now we keep track of the number of AAAAs (or TTTTs via
+        // canonicalization) in the file; note we also get the position (i.0;
+        // in the event there were `N`-containing kmers that were skipped)
+        // and whether the sequence was complemented (i.2) in addition to
+        // the canonical kmer (i.1)
+        for (_, kmer, _) in norm_seq.canonical_kmers(4, &rc) {
+            if kmer == b"AAAA" {
+                n_valid_kmers += 1;
+            }
+        }
+    }
+    println!("There are {} bases in your file.", n_bases);
+    println!("There are {} AAAAs in your file.", n_valid_kmers);
+
+    Ok(())
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -143,6 +143,17 @@ impl From<io::Error> for ParseError {
     }
 }
 
+impl From<niffler::Error> for ParseError {
+    fn from(err: niffler::Error) -> ParseError {
+        ParseError {
+            msg: err.to_string(),
+            kind: ParseErrorKind::Io,
+            position: ErrorPosition::default(),
+            format: None,
+        }
+    }
+}
+
 impl StdError for ParseError {
     fn cause(&self) -> Option<&dyn StdError> {
         // Ideally we would pass the io::Error but we don't for simplicity sake

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,13 +3,6 @@ use std::fs::File;
 use std::io::{Cursor, Read};
 use std::path::Path;
 
-#[cfg(feature = "compression")]
-use bzip2::read::BzDecoder;
-#[cfg(feature = "compression")]
-use flate2::read::MultiGzDecoder;
-#[cfg(feature = "compression")]
-use xz2::read::XzDecoder;
-
 use crate::errors::ParseError;
 pub use crate::parser::fasta::Reader as FastaReader;
 pub use crate::parser::fastq::Reader as FastqReader;
@@ -25,102 +18,39 @@ pub use crate::parser::utils::FastxReader;
 // TODO: for now this drops support for stdin parsing. It could be added back if needed though
 // by adding a method to the readers to set some initial buffer.
 
-fn read_file(mut f: Box<dyn Read>) -> Result<Box<dyn FastxReader>, ParseError> {
+/// The main entry point of needletail.
+/// Parses the file given a path and return an iterator-like reader struct.
+/// This automatically detects whether the file is:
+/// 1. compressed: gzip, bz and xz are supported and will use the appropriate decoder
+/// 2. FASTA or FASTQ: the right parser will be automatically instantiated
+/// 1 is only available if the `compression` feature is enabled.
+pub fn parse_fastx_file<P: AsRef<Path>>(path: P) -> Result<Box<dyn FastxReader>, ParseError> {
+    let f = File::open(path)?;
+    parse_fastx_reader(Box::new(f))
+}
+
+/// The main entry point of needletail.
+/// Parses the file given a path and return an iterator-like reader struct.
+/// This automatically detects whether the file is:
+/// 1. compressed: gzip, bz and xz are supported and will use the appropriate decoder
+/// 2. FASTA or FASTQ: the right parser will be automatically instantiated
+/// 1 is only available if the `compression` feature is enabled.
+pub fn parse_fastx_reader<'a, R: Read + 'a>(
+    rdr: R,
+) -> Result<Box<dyn FastxReader + 'a>, ParseError> {
+    // TODO: fix unwrap
+    let (mut reader, _) = niffler::get_reader(Box::new(rdr)).unwrap();
+
     let mut first = [0; 1];
-    f.read_exact(&mut first)?;
+    reader.read_exact(&mut first)?;
 
     let cursor = Cursor::new(first);
     match first[0] {
-        b'>' => Ok(Box::new(FastaReader::new(cursor.chain(f)))),
-        b'@' => Ok(Box::new(FastqReader::new(cursor.chain(f)))),
+        b'>' => Ok(Box::new(FastaReader::new(cursor.chain(reader)))),
+        b'@' => Ok(Box::new(FastqReader::new(cursor.chain(reader)))),
         _ => Err(ParseError::new_unknown_format(first[0])),
     }
 }
-
-/// The main entry point of needletail.
-/// Parses the file given a path and return an iterator-like reader struct.
-/// This automatically detects whether the file is:
-/// 1. compressed: gzip, bz and xz are supported and will use the appropriate decoder
-/// 2. FASTA or FASTQ: the right parser will be automatically instantiated
-/// 1 is only available if the `compression` feature is enabled.
-#[cfg(not(feature = "compression"))]
-pub fn parse_fastx_file<P: AsRef<Path>>(path: P) -> Result<Box<dyn FastxReader>, ParseError> {
-    let f = File::open(&path)?;
-    read_file(Box::new(f))
-}
-
-// Magic bytes for each compression format
-#[cfg(feature = "compression")]
-const GZ_MAGIC: [u8; 2] = [0x1F, 0x8B];
-#[cfg(feature = "compression")]
-const BZ_MAGIC: [u8; 2] = [0x42, 0x5A];
-#[cfg(feature = "compression")]
-const XZ_MAGIC: [u8; 2] = [0xFD, 0x37];
-
-/// The main entry point of needletail.
-/// Parses the file given a path and return an iterator-like reader struct.
-/// This automatically detects whether the file is:
-/// 1. compressed: gzip, bz and xz are supported and will use the appropriate decoder
-/// 2. FASTA or FASTQ: the right parser will be automatically instantiated
-/// 1 is only available if the `compression` feature is enabled.
-#[cfg(feature = "compression")]
-pub fn parse_fastx_file<P: AsRef<Path>>(path: P) -> Result<Box<dyn FastxReader>, ParseError> {
-    let mut f = File::open(&path)?;
-    let mut first = [0; 2];
-    f.read_exact(&mut first)?;
-
-    let cursor = Cursor::new(first);
-    let f = cursor.chain(f);
-    // Not great to say the least, we load the decoder twice since they don't impl Seek.
-    // That would cause an issue for compressed gzip and is probably not great for performance
-    // Not much compared to decompression overall but still
-    match first {
-        GZ_MAGIC => {
-            let mut gz_reader = MultiGzDecoder::new(f);
-            let mut first = [0; 1];
-            gz_reader.read_exact(&mut first)?;
-            match first[0] {
-                b'>' => Ok(Box::new(FastaReader::new(MultiGzDecoder::new(File::open(
-                    &path,
-                )?)))),
-                b'@' => Ok(Box::new(FastqReader::new(MultiGzDecoder::new(File::open(
-                    &path,
-                )?)))),
-                _ => Err(ParseError::new_unknown_format(first[0])),
-            }
-        }
-        BZ_MAGIC => {
-            let mut bz_reader = BzDecoder::new(f);
-            let mut first = [0; 1];
-            bz_reader.read_exact(&mut first)?;
-            match first[0] {
-                b'>' => Ok(Box::new(FastaReader::new(BzDecoder::new(File::open(
-                    &path,
-                )?)))),
-                b'@' => Ok(Box::new(FastqReader::new(BzDecoder::new(File::open(
-                    &path,
-                )?)))),
-                _ => Err(ParseError::new_unknown_format(first[0])),
-            }
-        }
-        XZ_MAGIC => {
-            let mut xz_reader = XzDecoder::new(f);
-            let mut first = [0; 1];
-            xz_reader.read_exact(&mut first)?;
-            match first[0] {
-                b'>' => Ok(Box::new(FastaReader::new(XzDecoder::new(File::open(
-                    &path,
-                )?)))),
-                b'@' => Ok(Box::new(FastqReader::new(XzDecoder::new(File::open(
-                    &path,
-                )?)))),
-                _ => Err(ParseError::new_unknown_format(first[0])),
-            }
-        }
-        _ => read_file(Box::new(f)),
-    }
-}
-
 // TODO: add a method that parses a string but handles decompression as well?
 
 pub use record::{mask_header_tabs, mask_header_utf8, write_fasta, write_fastq, SequenceRecord};

--- a/tests/test_stdin.rs
+++ b/tests/test_stdin.rs
@@ -1,0 +1,113 @@
+use std::io::{Seek, SeekFrom, Write};
+
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+
+#[cfg(feature = "compression")]
+#[test]
+fn test_stdin_gz() {
+    // Generated with `echo ">id1\nAGTCGTCA" | gzip -c | xxd  -i`
+    let input: &[u8] = &[
+        0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xb3, 0xcb, 0x4c, 0x31, 0xe4,
+        0x72, 0x74, 0x0f, 0x71, 0x06, 0x22, 0x47, 0x2e, 0x00, 0x9e, 0x3a, 0x32, 0x8c, 0x0e, 0x00,
+        0x00, 0x00,
+    ];
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(input).unwrap();
+    file.flush().unwrap();
+    file.seek(SeekFrom::Start(0)).unwrap();
+
+    escargot::CargoBuild::new()
+        .example("stdin_pipe")
+        .current_release()
+        .current_target()
+        .run()
+        .unwrap()
+        .command()
+        .stdin(file.into_file())
+        .assert()
+        .success()
+        .stdout(contains("There are 8 bases in your file"))
+        .stdout(contains("There are 0 AAAAs in your file"));
+}
+
+#[cfg(feature = "compression")]
+#[test]
+fn test_stdin_xz() {
+    // Generated with `echo ">id1\nAGTCGTCA" | xz -c | xxd  -i`
+    let input: &[u8] = &[
+        0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00, 0x00, 0x04, 0xe6, 0xd6, 0xb4, 0x46, 0x02, 0x00, 0x21,
+        0x01, 0x16, 0x00, 0x00, 0x00, 0x74, 0x2f, 0xe5, 0xa3, 0x01, 0x00, 0x0d, 0x3e, 0x69, 0x64,
+        0x31, 0x0a, 0x41, 0x47, 0x54, 0x43, 0x47, 0x54, 0x43, 0x41, 0x0a, 0x00, 0x00, 0x00, 0x12,
+        0x0f, 0x91, 0x75, 0xef, 0x7b, 0x63, 0x17, 0x00, 0x01, 0x26, 0x0e, 0x08, 0x1b, 0xe0, 0x04,
+        0x1f, 0xb6, 0xf3, 0x7d, 0x01, 0x00, 0x00, 0x00, 0x00, 0x04, 0x59, 0x5a,
+    ];
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(input).unwrap();
+    file.flush().unwrap();
+    file.seek(SeekFrom::Start(0)).unwrap();
+
+    escargot::CargoBuild::new()
+        .example("stdin_pipe")
+        .current_release()
+        .current_target()
+        .run()
+        .unwrap()
+        .command()
+        .stdin(file.into_file())
+        .assert()
+        .success()
+        .stdout(contains("There are 8 bases in your file"))
+        .stdout(contains("There are 0 AAAAs in your file"));
+}
+
+#[cfg(feature = "compression")]
+#[test]
+fn test_stdin_bzip() {
+    // Generated with `echo ">id1\nAGTCGTCA" | bzip2 -c | xxd  -i`
+    let input: &[u8] = &[
+        0x42, 0x5a, 0x68, 0x39, 0x31, 0x41, 0x59, 0x26, 0x53, 0x59, 0x9f, 0x9d, 0xf9, 0xa2, 0x00,
+        0x00, 0x01, 0xcf, 0x00, 0x00, 0x10, 0x20, 0x01, 0x28, 0x80, 0x04, 0x00, 0x04, 0x20, 0x20,
+        0x00, 0x22, 0x0c, 0x9a, 0x64, 0x20, 0xc9, 0x88, 0x21, 0x95, 0x8e, 0x82, 0x75, 0x27, 0x8b,
+        0xb9, 0x22, 0x9c, 0x28, 0x48, 0x4f, 0xce, 0xfc, 0xd1, 0x00,
+    ];
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(input).unwrap();
+    file.flush().unwrap();
+    file.seek(SeekFrom::Start(0)).unwrap();
+
+    escargot::CargoBuild::new()
+        .example("stdin_pipe")
+        .current_release()
+        .current_target()
+        .run()
+        .unwrap()
+        .command()
+        .stdin(file.into_file())
+        .assert()
+        .success()
+        .stdout(contains("There are 8 bases in your file"))
+        .stdout(contains("There are 0 AAAAs in your file"));
+}
+
+#[test]
+fn test_stdin_no_compression() {
+    let input: &[u8] = b">id1\nAGTCGTCA";
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    file.write_all(input).unwrap();
+    file.flush().unwrap();
+    file.seek(SeekFrom::Start(0)).unwrap();
+
+    escargot::CargoBuild::new()
+        .example("stdin_pipe")
+        .current_release()
+        .current_target()
+        .run()
+        .unwrap()
+        .command()
+        .stdin(file.into_file())
+        .assert()
+        .success()
+        .stdout(contains("There are 8 bases in your file"))
+        .stdout(contains("There are 0 AAAAs in your file"));
+}


### PR DESCRIPTION
- Using io::Cursor and Box to avoid the Seek bound.
- Uses niffler to replace the compression detection logic
- Added `parse_fastx_reader` as the main method, and `parse_fastx_file` then becomes just a small shim that opens a `File` and passes to `parse_fastx_reader`
- Brings back stdin support in `parse_fastx_file`

(From https://github.com/onecodex/needletail/pull/45#issuecomment-650496860)