### PR TITLE
Add EmptyFile error kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+- `ParseErrorKind::EmptyFile` variant to handle cases where there are less than two bytes in a file [[#51][51]]
+
 ## [0.4.0] - 2020-07-08
 
 ## Changed
@@ -36,3 +39,5 @@ to the input one.
 ## [0.3.1] - 2019-09-18
 ### Fixed
 - Needletail no longer runs out of memory when parsing large, compressed files.
+
+[51]: https://github.com/onecodex/needletail/issues/51

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,6 +38,8 @@ pub enum ParseErrorKind {
     UnequalLengths,
     /// Truncated record found
     UnexpectedEnd,
+    /// The file appears to be empty
+    EmptyFile,
 }
 
 /// The only error type that needletail returns
@@ -115,6 +117,15 @@ impl ParseError {
             format: Some(format),
         }
     }
+
+    pub fn new_empty_file() -> Self {
+        ParseError {
+            msg: String::from("Failed to read the first two bytes. Is the file empty?"),
+            kind: ParseErrorKind::EmptyFile,
+            position: ErrorPosition::default(),
+            format: None,
+        }
+    }
 }
 
 impl fmt::Display for ParseError {
@@ -124,6 +135,7 @@ impl fmt::Display for ParseError {
             ParseErrorKind::UnequalLengths
             | ParseErrorKind::InvalidStart
             | ParseErrorKind::UnknownFormat
+            | ParseErrorKind::EmptyFile
             | ParseErrorKind::InvalidSeparator => write!(f, "{} ({})", self.msg, self.position),
             ParseErrorKind::UnexpectedEnd => {
                 write!(f, "Unexpected end of input ({}).", self.position)

--- a/src/kmer.rs
+++ b/src/kmer.rs
@@ -4,10 +4,7 @@
 /// Returns true if the base is a unambiguous nucleic acid base (e.g. ACGT) and
 /// false otherwise.
 fn is_good_base(chr: u8) -> bool {
-    match chr as char {
-        'a' | 'c' | 'g' | 't' | 'A' | 'C' | 'G' | 'T' => true,
-        _ => false,
-    }
+    matches!(chr as char, 'a' | 'c' | 'g' | 't' | 'A' | 'C' | 'G' | 'T')
 }
 
 /// Generic moving window iterator over sequences to return k-mers


### PR DESCRIPTION
Closes #51 

## Added
- `ParseErrorKind::EmptyFile` variant to handle cases where there are less than two bytes in a file [#51]

I also expanded on the documentation for `parse_fastx_reader`. Let me know if this is not correct, or if you would prefer it removed.