### PR TITLE
add `num_gaps` function for record

### DIFF
--- a/src/parser/fasta.rs
+++ b/src/parser/fasta.rs
@@ -110,8 +110,8 @@ impl BufferPosition {
     pub(crate) fn num_gaps(&self, buffer: &[u8]) -> usize {
         let seq = self.raw_seq(buffer);
         let num_gaps_n = bytecount::count(seq, b'n');
-        let num_gaps_N = bytecount::count(seq, b'N');
-        num_gaps_n + num_gaps_N
+        let num_gaps_n_upper = bytecount::count(seq, b'N');
+        num_gaps_n + num_gaps_n_upper
     }
 }
 

--- a/src/parser/fastq.rs
+++ b/src/parser/fastq.rs
@@ -56,8 +56,8 @@ impl BufferPosition {
     #[inline]
     pub(crate) fn num_gaps<'a>(&'a self, buffer: &'a [u8]) -> usize {
         let num_gap_n = bytecount::count(self.seq(buffer), b'n');
-        let num_gap_N = bytecount::count(self.seq(buffer), b'N');
-        num_gap_n + num_gap_N
+        let num_gap_n_upper = bytecount::count(self.seq(buffer), b'N');
+        num_gap_n + num_gap_n_upper
     }
 
     #[inline]

--- a/src/parser/fastq.rs
+++ b/src/parser/fastq.rs
@@ -54,6 +54,13 @@ impl BufferPosition {
     }
 
     #[inline]
+    pub(crate) fn num_gaps<'a>(&'a self, buffer: &'a [u8]) -> usize {
+        let num_gap_n = bytecount::count(self.seq(buffer), b'n');
+        let num_gap_N = bytecount::count(self.seq(buffer), b'N');
+        num_gap_n + num_gap_N
+    }
+
+    #[inline]
     fn find_line_ending<'a>(&'a self, buffer: &'a [u8]) -> Option<LineEnding> {
         find_line_ending(self.all(buffer))
     }

--- a/src/parser/record.rs
+++ b/src/parser/record.rs
@@ -118,6 +118,15 @@ impl<'a> SequenceRecord<'a> {
         }
     }
 
+    /// Return the numer of gaps(n | N) in the sequence, computed efficiently.
+    #[inline]
+    pub fn num_gaps(&self) -> usize {
+        match self.buf_pos {
+            BufferPositionKind::Fasta(bp) => bp.num_gaps(self.buffer),
+            BufferPositionKind::Fastq(bp) => bp.num_gaps(self.buffer),
+        }
+    }
+
     /// Return the line number in the file of the start of the sequence
     pub fn start_line_number(&self) -> u64 {
         self.position.line


### PR DESCRIPTION
Hi, for some statistic of fast[a,q] files, count the gaps('n' or 'N', maybe '-' but not considered here) in a sequence could be necessary.

So, I add such a functions simply, and add a test case.

Best wishes.