### PR TITLE
Migrate xz2 to liblzma

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ xz2 = ["liblzma"]
 buffer-redux = { version = "1", default_features = false }
 bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
 bzip2 = { version = "0.4", optional = true }
-flate2 = { version = "1.0.28", optional = true }
+flate2 = { version = "1.0.30", optional = true }
 memchr = "2.7.2"
 pyo3 = { version = "0.21.2", optional = true }
 liblzma = { version = "0.3.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ xz2 = ["liblzma"]
 buffer-redux = { version = "1", default_features = false }
 bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
 bzip2 = { version = "0.4", optional = true }
-flate2 = { version = "1.0.6", optional = true }
-memchr = "2.2.1"
-pyo3 = { version = "0.18", optional = true }
+flate2 = { version = "1.0.28", optional = true }
+memchr = "2.7.2"
+pyo3 = { version = "0.21.2", optional = true }
 liblzma = { version = "0.3.1", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default = ["compression"]
 compression = ["bzip2", "flate2", "xz2"]
 python = ["pyo3/extension-module"]
 python_test = ["pyo3"]
+xz2 = ["liblzma"]
 
 [dependencies]
 buffer-redux = { version = "1", default_features = false }
@@ -28,7 +29,7 @@ bzip2 = { version = "0.4", optional = true }
 flate2 = { version = "1.0.6", optional = true }
 memchr = "2.2.1"
 pyo3 = { version = "0.18", optional = true }
-xz2 = { version = "0.1.6", optional = true }
+liblzma = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8,7 +8,7 @@ use bzip2::read::BzDecoder;
 #[cfg(feature = "flate2")]
 use flate2::read::MultiGzDecoder;
 #[cfg(feature = "xz2")]
-use xz2::read::XzDecoder;
+use liblzma::read::XzDecoder;
 
 use crate::errors::ParseError;
 pub use crate::parser::fasta::Reader as FastaReader;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,11 +3,11 @@ use std::fs::File;
 use std::io::{stdin, Cursor, Read};
 use std::path::Path;
 
-#[cfg(feature = "compression")]
+#[cfg(feature = "bzip2")]
 use bzip2::read::BzDecoder;
-#[cfg(feature = "compression")]
+#[cfg(feature = "flate2")]
 use flate2::read::MultiGzDecoder;
-#[cfg(feature = "compression")]
+#[cfg(feature = "xz2")]
 use xz2::read::XzDecoder;
 
 use crate::errors::ParseError;
@@ -23,11 +23,11 @@ mod fastq;
 pub use crate::parser::utils::FastxReader;
 
 // Magic bytes for each compression format
-#[cfg(feature = "compression")]
+#[cfg(feature = "flate2")]
 const GZ_MAGIC: [u8; 2] = [0x1F, 0x8B];
-#[cfg(feature = "compression")]
+#[cfg(feature = "bzip2")]
 const BZ_MAGIC: [u8; 2] = [0x42, 0x5A];
-#[cfg(feature = "compression")]
+#[cfg(feature = "xz2")]
 const XZ_MAGIC: [u8; 2] = [0xFD, 0x37];
 
 fn get_fastx_reader<'a, R: 'a + io::Read + Send>(
@@ -88,7 +88,7 @@ pub fn parse_fastx_reader<'a, R: 'a + io::Read + Send>(
     let new_reader = first_two_cursor.chain(reader);
 
     match first_two_bytes {
-        #[cfg(feature = "compression")]
+        #[cfg(feature = "flate2")]
         GZ_MAGIC => {
             let mut gz_reader = MultiGzDecoder::new(new_reader);
             let mut first = [0; 1];
@@ -96,7 +96,7 @@ pub fn parse_fastx_reader<'a, R: 'a + io::Read + Send>(
             let r = Cursor::new(first).chain(gz_reader);
             get_fastx_reader(r, first[0])
         }
-        #[cfg(feature = "compression")]
+        #[cfg(feature = "bzip2")]
         BZ_MAGIC => {
             let mut bz_reader = BzDecoder::new(new_reader);
             let mut first = [0; 1];
@@ -104,7 +104,7 @@ pub fn parse_fastx_reader<'a, R: 'a + io::Read + Send>(
             let r = Cursor::new(first).chain(bz_reader);
             get_fastx_reader(r, first[0])
         }
-        #[cfg(feature = "compression")]
+        #[cfg(feature = "xz2")]
         XZ_MAGIC => {
             let mut xz_reader = XzDecoder::new(new_reader);
             let mut first = [0; 1];

--- a/src/python.rs
+++ b/src/python.rs
@@ -128,13 +128,13 @@ pub fn reverse_complement(seq: &str) -> String {
 }
 
 #[pymodule]
-fn needletail(py: Python, m: &PyModule) -> PyResult<()> {
+fn needletail(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyFastxReader>()?;
     m.add_wrapped(wrap_pyfunction!(parse_fastx_file))?;
     m.add_wrapped(wrap_pyfunction!(parse_fastx_string))?;
     m.add_wrapped(wrap_pyfunction!(normalize_seq))?;
     m.add_wrapped(wrap_pyfunction!(reverse_complement))?;
-    m.add("NeedletailError", py.get_type::<NeedletailError>())?;
+    m.add("NeedletailError", py.get_type_bound::<NeedletailError>())?;
 
     Ok(())
 }


### PR DESCRIPTION
Looks like liblzma is becoming the new xz lib, this moves it over, while leaving the feature flag as xz2 (happy to change it).

Some other deps are outdated, I'd be happy to update them if you like. 

Cheers,
--Joseph