### PR TITLE
Add `position` method to Record.

### DIFF
--- a/src/parser/record.rs
+++ b/src/parser/record.rs
@@ -231,13 +231,14 @@ mod test {
     use std::io::Cursor;
 
     use crate::parse_fastx_reader;
-    fn seq(s: &[u8]) -> Cursor<&[u8]> { Cursor::new(s) }
+    fn seq(s: &[u8]) -> Cursor<&[u8]> {
+        Cursor::new(s)
+    }
 
     #[test]
     fn test_start_line_number() {
-        let mut reader = parse_fastx_reader(seq(
-            b"@test\nACGT\n+\nIIII\n@test2\nACGT\n+\nIIII"
-        )).unwrap();
+        let mut reader =
+            parse_fastx_reader(seq(b"@test\nACGT\n+\nIIII\n@test2\nACGT\n+\nIIII")).unwrap();
 
         let rec = reader.next().unwrap().unwrap();
         assert_eq!(rec.start_line_number(), 1);
@@ -249,8 +250,9 @@ mod test {
     #[test]
     fn test_position() {
         let mut reader = parse_fastx_reader(seq(
-            b"@test1\nACGT\n+\nIIII\n@test222\nACGT\n+\nIIII\n@test3\nACGT\n+\nIIII"
-        )).unwrap();
+            b"@test1\nACGT\n+\nIIII\n@test222\nACGT\n+\nIIII\n@test3\nACGT\n+\nIIII",
+        ))
+        .unwrap();
 
         let rec = reader.next().unwrap().unwrap();
         assert_eq!(rec.position().byte(), 0);

--- a/src/parser/record.rs
+++ b/src/parser/record.rs
@@ -123,6 +123,11 @@ impl<'a> SequenceRecord<'a> {
         self.position.line
     }
 
+    /// Return the line/byte position of the start of the sequence
+    pub fn position(&self) -> &Position {
+        self.position
+    }
+
     /// Which line ending is this record using?
     pub fn line_ending(&self) -> LineEnding {
         self.line_ending

--- a/src/parser/record.rs
+++ b/src/parser/record.rs
@@ -225,3 +225,40 @@ pub fn write_fastq(
     writer.write_all(&ending)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use std::io::Cursor;
+
+    use crate::parse_fastx_reader;
+    fn seq(s: &[u8]) -> Cursor<&[u8]> { Cursor::new(s) }
+
+    #[test]
+    fn test_start_line_number() {
+        let mut reader = parse_fastx_reader(seq(
+            b"@test\nACGT\n+\nIIII\n@test2\nACGT\n+\nIIII"
+        )).unwrap();
+
+        let rec = reader.next().unwrap().unwrap();
+        assert_eq!(rec.start_line_number(), 1);
+
+        let rec = reader.next().unwrap().unwrap();
+        assert_eq!(rec.start_line_number(), 5);
+    }
+
+    #[test]
+    fn test_position() {
+        let mut reader = parse_fastx_reader(seq(
+            b"@test1\nACGT\n+\nIIII\n@test222\nACGT\n+\nIIII\n@test3\nACGT\n+\nIIII"
+        )).unwrap();
+
+        let rec = reader.next().unwrap().unwrap();
+        assert_eq!(rec.position().byte(), 0);
+
+        let rec = reader.next().unwrap().unwrap();
+        assert_eq!(rec.position().byte(), 19);
+
+        let rec = reader.next().unwrap().unwrap();
+        assert_eq!(rec.position().byte(), 40);
+    }
+}


### PR DESCRIPTION
Hey, thanks for your work on this library!

Currently, the `position` field of each `SequenceRecord` object is private and inaccessible. Furthermore, due to borrowing rules, it can be difficult to retrieve the active position of a `FastxReader` while also reading a record (this seems to lead to a conflict between both an immutable and mutable borrow).

While an existing method exists on `SequenceRecord`, `start_line_number(&self)`, this only returns the line number. I've found a need for information about the records at the byte level, not just the line level, so there is a need to access the underlying `Position` object. 

This commit is small and adds a getter to each `SequenceRecord` to make a reference to the position accessible. 

Thanks!