### PR TITLE
Fix Clippy error: elide lifetime

### DIFF
--- a/src/bitkmer.rs
+++ b/src/bitkmer.rs
@@ -91,7 +91,7 @@ impl<'a> BitNuclKmer<'a> {
     }
 }
 
-impl<'a> Iterator for BitNuclKmer<'a> {
+impl Iterator for BitNuclKmer<'_> {
     type Item = (usize, BitKmer, bool);
 
     fn next(&mut self) -> Option<(usize, BitKmer, bool)> {


### PR DESCRIPTION
Fixes new Clippy error:

```
🐝  cargo +stable clippy                                                                                                                         needletail
    Checking needletail v0.6.0 (/home/audy/Code/needletail)
warning: the following explicit lifetimes could be elided: 'a
  --> src/bitkmer.rs:94:6
   |
94 | impl<'a> Iterator for BitNuclKmer<'a> {
   |      ^^                           ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
   |
94 - impl<'a> Iterator for BitNuclKmer<'a> {
94 + impl Iterator for BitNuclKmer<'_> {
```