### PR TITLE
Set PyO3 bindings in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,7 @@ classifier = [
     "License :: OSI Approved :: MIT License",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
+
+[tool.maturin]
+bindings = "pyo3"
+features = ["python"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=1.7,<2.0"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
As highlighted by @luizirber in [this comment](https://github.com/bioconda/bioconda-recipes/pull/52723#issuecomment-2552599503), Maturin is not configured to use PyO3. Instead, the automatic detection incorrectly identifies the package as using CFFI bindings (not sure why).

This PR explicitly sets the PyO3 bindings in the `pyproject.toml` file. All credits go to @luizirber.