### PR TITLE
Add dunder methods to the Python `Record` class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv/
 .DS_Store
 .idea/
 test.py
+__pycache__/

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,6 +1,7 @@
 //! Python bindings for needletail
 
 // TODO:
+// - Make the return values of `__repr__` and `__str__` show up as raw strings.
 // - Add support for `pathlib.Path` objects in `parse_fastx_file`.
 // - Make `normalize_seq` and `reverse_complement` functions able to handle
 //  `Record` objects as input.

--- a/src/python.rs
+++ b/src/python.rs
@@ -59,10 +59,12 @@ impl Record {
 
 #[pymethods]
 impl Record {
+    #[getter]
     pub fn is_fasta(&self) -> PyResult<bool> {
         Ok(self.qual.is_none())
     }
 
+    #[getter]
     pub fn is_fastq(&self) -> PyResult<bool> {
         Ok(self.qual.is_some())
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -139,14 +139,7 @@ impl Record {
 
     pub fn __str__(&self) -> PyResult<String> {
         if self.qual.is_none() {
-            let wrapped_seq = self
-                .seq
-                .as_bytes()
-                .chunks(60)
-                .map(|chunk| String::from_utf8_lossy(chunk).to_string())
-                .collect::<Vec<String>>()
-                .join("\n");
-            Ok(format!(">{}\n{}", self.id, wrapped_seq))
+            Ok(format!(">{}\n{}", self.id, self.seq))
         } else {
             Ok(format!(
                 "@{}\n{}\n+\n{}",

--- a/src/python.rs
+++ b/src/python.rs
@@ -179,6 +179,7 @@ impl Record {
     /// See also
     /// --------
     /// normalize_seq: A function to normalize nucleotide sequence strings.
+    #[pyo3(signature = (iupac=false))]
     pub fn normalize(&mut self, iupac: bool) -> PyResult<()> {
         if let Some(s) = normalize(self.seq.as_bytes(), iupac) {
             self.seq = String::from_utf8_lossy(&s).to_string();
@@ -311,17 +312,20 @@ fn parse_fastx_string(content: &str) -> PyResult<PyFastxReader> {
 }
 
 /// Normalize the sequence string of nucleotide records by:
-/// - Converting lowercase characters to uppercase.
-/// - Removing whitespace and newline characters.
-/// - Replacing 'U' with 'T'.
-/// - Replacing '.' and '~' with '-'.
-/// - Replacing characters not in 'ACGTN-' with 'N'.
+///
+///     - Converting lowercase characters to uppercase.
+///     - Removing whitespace and newline characters.
+///     - Replacing 'U' with 'T'.
+///     - Replacing '.' and '~' with '-'.
+///     - Replacing characters not in 'ACGTN-' with 'N', unless `iupac` is set
+///       to `True`, in which case characters representing nucleotide ambiguity
+///       are not replaced.
 ///
 /// Parameters
 /// ----------
 /// seq : str
 ///     A string representing a nucleotide sequence.
-/// iupac : bool
+/// iupac : bool, default: False
 ///     If `True`, characters representing nucleotide ambiguity ('B', 'D',
 ///     'H', 'V', 'R', 'Y', 'S', 'W', 'K', and 'M', and their lowercase
 ///     forms) will not be converted to 'N'. Lowercase characters will still
@@ -338,6 +342,7 @@ fn parse_fastx_string(content: &str) -> PyResult<PyFastxReader> {
 /// used with protein sequences, it will incorrectly process amino acid
 /// characters as if they were nucleotides.
 #[pyfunction]
+#[pyo3(signature = (seq, iupac=false))]
 pub fn normalize_seq(seq: &str, iupac: bool) -> PyResult<String> {
     if let Some(s) = normalize(seq.as_bytes(), iupac) {
         Ok(String::from_utf8_lossy(&s).to_string())

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,6 +1,8 @@
 //! Python bindings for needletail
 
 // TODO:
+// - Add a property to the `Record` class that returns the quality scores as a
+//   list of integers.
 // - Make the return values of `__repr__` and `__str__` show up as raw strings.
 // - Make `normalize_seq` and `reverse_complement` functions able to handle
 //  `Record` objects as input.

--- a/src/python.rs
+++ b/src/python.rs
@@ -163,13 +163,13 @@ impl Record {
             Ok(name) => name.to_string(),
             Err(_) => self.id.clone(),
         };
-        let seq_snippet = get_seq_snippet(&self.seq, 30);
+        let seq_snippet = get_seq_snippet(&self.seq, 25);
         let quality_snippet = match &self.qual {
-            Some(qual) => get_seq_snippet(qual, 30),
+            Some(qual) => get_seq_snippet(qual, 25),
             None => "None".to_string(),
         };
         Ok(format!(
-            "Record(id={}, sequence={}, quality={})",
+            "Record(id={}, seq={}, qual={})",
             id_snippet, seq_snippet, quality_snippet
         ))
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -26,7 +26,7 @@ pub struct PyFastxReader {
     reader: Box<dyn FastxReader>,
 }
 
-fn get_string_snippet(seq: &str, max_len: usize) -> String {
+fn get_seq_snippet(seq: &str, max_len: usize) -> String {
     if seq.len() > max_len {
         let start = &seq[..max_len - 4];
         let end = &seq[seq.len() - 3..];
@@ -158,14 +158,19 @@ impl Record {
     }
 
     fn __repr__(&self) -> PyResult<String> {
-        let seq_snippet = get_string_snippet(&self.seq, 30);
+        let id_snippet = match self.name() {
+            Ok(name) if name != self.id => format!("{}…", name),
+            Ok(name) => name.to_string(),
+            Err(_) => self.id.clone(),
+        };
+        let seq_snippet = get_seq_snippet(&self.seq, 30);
         let quality_snippet = match &self.qual {
-            Some(qual) => get_string_snippet(qual, 30),
+            Some(qual) => get_seq_snippet(qual, 30),
             None => "None".to_string(),
         };
         Ok(format!(
             "Record(id={}, sequence={}, quality={})",
-            self.id, seq_snippet, quality_snippet
+            id_snippet, seq_snippet, quality_snippet
         ))
     }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,5 +1,7 @@
 //! Python bindings for needletail
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::io::Cursor;
 
 use pyo3::prelude::*;
@@ -71,6 +73,59 @@ impl Record {
             self.seq = String::from_utf8_lossy(&s).to_string();
         }
         Ok(())
+    }
+
+    pub fn __hash__(&self) -> PyResult<u64> {
+        let mut hasher = DefaultHasher::new();
+        self.id.hash(&mut hasher);
+        self.seq.hash(&mut hasher);
+        if !self.qual.is_none() {
+            self.qual.hash(&mut hasher);
+        }
+        Ok(hasher.finish())
+    }
+
+    pub fn __eq__(&self, other: &Record) -> PyResult<bool> {
+        Ok(self.id == other.id && self.seq == other.seq && self.qual == other.qual)
+    }
+
+    pub fn __len__(&self) -> PyResult<usize> {
+        Ok(self.seq.len())
+    }
+
+    pub fn __str__(&self) -> PyResult<String> {
+        if self.qual.is_none() {
+            let wrapped_seq = self
+                .seq
+                .as_bytes()
+                .chunks(60)
+                .map(|chunk| String::from_utf8_lossy(chunk).to_string())
+                .collect::<Vec<String>>()
+                .join("\n");
+            Ok(format!(">{}\n{}", self.id, wrapped_seq))
+        } else {
+            Ok(format!(
+                "@{}\n{}\n+\n{}",
+                self.id,
+                self.seq,
+                self.qual.clone().unwrap()
+            ))
+        }
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        let seq_preview = if self.seq.len() > 40 {
+            let start = &self.seq[..34];
+            let end = &self.seq[self.seq.len() - 3..];
+            format!("{}...{}", start, end)
+        } else {
+            self.seq.clone()
+        };
+        let has_quality = self.qual.is_some();
+        Ok(format!(
+            "Record(id={}, sequence={}, has_quality={})",
+            self.id, seq_preview, has_quality
+        ))
     }
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -315,13 +315,13 @@ fn parse_fastx_string(content: &str) -> PyResult<PyFastxReader> {
 
 /// Normalize the sequence string of nucleotide records by:
 ///
-///     - Converting lowercase characters to uppercase.
-///     - Removing whitespace and newline characters.
-///     - Replacing 'U' with 'T'.
-///     - Replacing '.' and '~' with '-'.
-///     - Replacing characters not in 'ACGTN-' with 'N', unless `iupac` is set
-///       to `True`, in which case characters representing nucleotide ambiguity
-///       are not replaced.
+/// - Converting lowercase characters to uppercase.
+/// - Removing whitespace and newline characters.
+/// - Replacing 'U' with 'T'.
+/// - Replacing '.' and '~' with '-'.
+/// - Replacing characters not in 'ACGTN-' with 'N', unless `iupac` is `True`,
+///   in which case characters representing nucleotide ambiguity are not
+///   replaced.
 ///
 /// Parameters
 /// ----------

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,5 +1,10 @@
 //! Python bindings for needletail
 
+// TODO:
+// - Add support for `pathlib.Path` objects in `parse_fastx_file`.
+// - Make `normalize_seq` and `reverse_complement` functions able to handle
+//  `Record` objects as input.
+
 use crate::sequence::{complement, normalize};
 use crate::{
     parse_fastx_file as rs_parse_fastx_file, parse_fastx_reader, parser::SequenceRecord,
@@ -243,9 +248,6 @@ impl Record {
         ))
     }
 }
-
-// TODO: what would be really nice is to detect the type of pyobject so it would on file object etc
-// not for initial release though
 
 /// An iterator that reads sequence records from a FASTA/FASTQ file.
 ///

--- a/src/python.rs
+++ b/src/python.rs
@@ -139,10 +139,10 @@ impl Record {
 
     pub fn __str__(&self) -> PyResult<String> {
         if self.qual.is_none() {
-            Ok(format!(">{}\n{}", self.id, self.seq))
+            Ok(format!(">{}\n{}\n", self.id, self.seq))
         } else {
             Ok(format!(
-                "@{}\n{}\n+\n{}",
+                "@{}\n{}\n+\n{}\n",
                 self.id,
                 self.seq,
                 self.qual.clone().unwrap()

--- a/src/python.rs
+++ b/src/python.rs
@@ -334,9 +334,9 @@ fn parse_fastx_string(content: &str) -> PyResult<PyFastxReader> {
 ///
 /// Notes
 /// -----
-///     The `normalize` method is designed for nucleotide sequences only. If
-///     used with protein sequences, it will incorrectly process amino acid
-///     characters as if they were nucleotides.
+/// The `normalize` method is designed for nucleotide sequences only. If
+/// used with protein sequences, it will incorrectly process amino acid
+/// characters as if they were nucleotides.
 #[pyfunction]
 pub fn normalize_seq(seq: &str, iupac: bool) -> PyResult<String> {
     if let Some(s) = normalize(seq.as_bytes(), iupac) {

--- a/src/python.rs
+++ b/src/python.rs
@@ -26,6 +26,16 @@ pub struct PyFastxReader {
     reader: Box<dyn FastxReader>,
 }
 
+fn get_string_snippet(seq: &str, max_len: usize) -> String {
+    if seq.len() > max_len {
+        let start = &seq[..max_len - 4];
+        let end = &seq[seq.len() - 3..];
+        format!("{}…{}", start, end)
+    } else {
+        seq.to_string()
+    }
+}
+
 #[pymethods]
 impl PyFastxReader {
     fn __repr__(&self) -> PyResult<String> {
@@ -130,28 +140,14 @@ impl Record {
     }
 
     fn __repr__(&self) -> PyResult<String> {
-        let seq_preview = if self.seq.len() > 30 {
-            let start = &self.seq[..26];
-            let end = &self.seq[self.seq.len() - 3..];
-            format!("{}…{}", start, end)
-        } else {
-            self.seq.clone()
-        };
-        let quality_preview = match &self.qual {
-            Some(qual) => {
-                if qual.len() > 30 {
-                    let start = &qual[..26];
-                    let end = &qual[qual.len() - 3..];
-                    format!("{}…{}", start, end)
-                } else {
-                    qual.clone()
-                }
-            }
+        let seq_snippet = get_string_snippet(&self.seq, 30);
+        let quality_snippet = match &self.qual {
+            Some(qual) => get_string_snippet(qual, 30),
             None => "None".to_string(),
         };
         Ok(format!(
             "Record(id={}, sequence={}, quality={})",
-            self.id, seq_preview, quality_preview
+            self.id, seq_snippet, quality_snippet
         ))
     }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -87,12 +87,10 @@ impl Record {
         }
     }
 
-    #[getter]
     pub fn is_fasta(&self) -> PyResult<bool> {
         Ok(self.qual.is_none())
     }
 
-    #[getter]
     pub fn is_fastq(&self) -> PyResult<bool> {
         Ok(self.qual.is_some())
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -2,7 +2,6 @@
 
 // TODO:
 // - Make the return values of `__repr__` and `__str__` show up as raw strings.
-// - Add support for `pathlib.Path` objects in `parse_fastx_file`.
 // - Make `normalize_seq` and `reverse_complement` functions able to handle
 //  `Record` objects as input.
 
@@ -17,6 +16,7 @@ use pyo3::prelude::*;
 use pyo3::{create_exception, wrap_pyfunction};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::Cursor;
+use std::path::PathBuf;
 
 create_exception!(needletail, NeedletailError, pyo3::exceptions::PyException);
 
@@ -254,7 +254,7 @@ impl Record {
 ///
 /// Parameters
 /// ----------
-/// path : str
+/// path : str or pathlib.Path
 ///     The path to a FASTA/FASTQ file.
 ///
 /// Returns
@@ -275,7 +275,7 @@ impl Record {
 /// PyFastxReader:
 ///     A class with instances that are iterators that yield `Record` objects.
 #[pyfunction]
-fn parse_fastx_file(path: &str) -> PyResult<PyFastxReader> {
+fn parse_fastx_file(path: PathBuf) -> PyResult<PyFastxReader> {
     let reader = py_try!(rs_parse_fastx_file(path));
     Ok(PyFastxReader { reader })
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -210,11 +210,11 @@ pub fn reverse_complement(seq: &str) -> String {
 #[pymodule]
 fn needletail(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyFastxReader>()?;
+    m.add_class::<Record>()?;
     m.add_wrapped(wrap_pyfunction!(parse_fastx_file))?;
     m.add_wrapped(wrap_pyfunction!(parse_fastx_string))?;
     m.add_wrapped(wrap_pyfunction!(normalize_seq))?;
     m.add_wrapped(wrap_pyfunction!(reverse_complement))?;
     m.add("NeedletailError", py.get_type_bound::<NeedletailError>())?;
-
     Ok(())
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -241,9 +241,9 @@ impl Record {
             Ok(name) => name.to_string(),
             Err(_) => self.id.clone(),
         };
-        let seq_snippet = get_seq_snippet(&self.seq, 25);
+        let seq_snippet = get_seq_snippet(&self.seq, 20);
         let quality_snippet = match &self.qual {
-            Some(qual) => get_seq_snippet(qual, 25),
+            Some(qual) => get_seq_snippet(qual, 20),
             None => "None".to_string(),
         };
         Ok(format!(

--- a/src/python.rs
+++ b/src/python.rs
@@ -70,6 +70,24 @@ impl Record {
 #[pymethods]
 impl Record {
     #[getter]
+    pub fn name(&self) -> PyResult<&str> {
+        if let Some(pos) = self.id.find(char::is_whitespace) {
+            Ok(&self.id[..pos])
+        } else {
+            Ok(&self.id)
+        }
+    }
+
+    #[getter]
+    pub fn description(&self) -> PyResult<Option<&str>> {
+        if let Some(pos) = self.id.find(char::is_whitespace) {
+            Ok(Some(&self.id[pos..].trim_start()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[getter]
     pub fn is_fasta(&self) -> PyResult<bool> {
         Ok(self.qual.is_none())
     }

--- a/test_python.py
+++ b/test_python.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from needletail import (
     NeedletailError,
-    PyFastxReader,
     Record,
     normalize_seq,
     parse_fastx_file,
@@ -148,12 +147,16 @@ class ReverseComplementTestCase(unittest.TestCase):
         self.assertEqual(reverse_complement("atcg"), "cgat")
 
 
-class FileParsingTestCase(unittest.TestCase):
+class StrParsingTestCase(unittest.TestCase):
     def get_fasta_reader(self):
-        return parse_fastx_file(FASTA_FILE)
+        with open(FASTA_FILE) as f:
+            content = f.read()
+            return parse_fastx_string(content)
 
     def get_fastq_reader(self):
-        return parse_fastx_file(FASTQ_FILE)
+        with open(FASTQ_FILE) as f:
+            content = f.read()
+            return parse_fastx_string(content)
 
     def test_can_parse_fasta_file(self):
         for i, record in enumerate(self.get_fasta_reader()):
@@ -179,23 +182,16 @@ class FileParsingTestCase(unittest.TestCase):
                 self.assertEqual(record.qual, ";;;;;;;;;;;7;;;;;-;;;3;83")
             self.assertTrue(i <= 2)
 
-    def test_pathlib_path_input(self):
-        self.assertIsInstance(parse_fastx_file(Path(FASTA_FILE)), PyFastxReader)
 
-
-class StrParsingTestCase(FileParsingTestCase):
+class FileParsingTestCase(StrParsingTestCase):
     def get_fasta_reader(self):
-        with open(FASTA_FILE) as f:
-            content = f.read()
-            return parse_fastx_string(content)
+        return parse_fastx_file(FASTA_FILE)
 
     def get_fastq_reader(self):
-        with open(FASTQ_FILE) as f:
-            content = f.read()
-            return parse_fastx_string(content)
+        return parse_fastx_file(FASTQ_FILE)
 
     def test_pathlib_path_input(self):
-        pass
+        parse_fastx_file(Path(FASTA_FILE))
 
 
 class ErroringTestCase(unittest.TestCase):

--- a/test_python.py
+++ b/test_python.py
@@ -1,13 +1,153 @@
 import unittest
+from pathlib import Path
 
-from needletail import parse_fastx_file, parse_fastx_string, NeedletailError, reverse_complement, normalize_seq
-
+from needletail import (
+    NeedletailError,
+    Record,
+    normalize_seq,
+    parse_fastx_file,
+    parse_fastx_string,
+    reverse_complement,
+)
 
 FASTA_FILE = "./tests/data/test.fa"
 FASTQ_FILE = "./tests/specimen/FASTQ/example.fastq"
 
 
-class ParsingTestCase(unittest.TestCase):
+class RecordClassTestCase(unittest.TestCase):
+    def test_fasta_record(self):
+        record = Record("test description", "AGCTGATCGA")
+        self.assertEqual(record.id, "test description")
+        self.assertEqual(record.seq, "AGCTGATCGA")
+        self.assertIsNone(record.qual)
+
+    def test_fastq_record(self):
+        record = Record("test description", "AGCTGATCGA", ";**9;;????")
+        self.assertEqual(record.id, "test description")
+        self.assertEqual(record.seq, "AGCTGATCGA")
+        self.assertEqual(record.qual, ";**9;;????")
+
+    def test_record_properties(self):
+        record = Record("test description", "AGCTGATCGA")
+        self.assertEqual(record.name, "test")
+        self.assertEqual(record.description, "description")
+
+    def test_record_normalize(self):
+        record = Record("test", "AGCTGYrtcga")
+        record.normalize(iupac=True)
+        self.assertEqual(record.seq, "AGCTGYRTCGA")
+        record.normalize()
+        self.assertEqual(record.seq, "AGCTGNNTCGA")
+
+    def test_format_record_method(self):
+        record = Record("test", "AGCTGATCGA")
+        self.assertTrue(record.is_fasta())
+        self.assertFalse(record.is_fastq())
+        record = Record("test", "AGCTGATCGA", ";**9;;????")
+        self.assertFalse(record.is_fasta())
+        self.assertTrue(record.is_fastq())
+
+    def test_record_eq(self):
+        record1 = Record("test", "AGCTGATCGA", ";**9;;????")
+        record2 = Record("test", "AGCTGATCGA", ";**9;;????")
+        record3 = Record("test2", "AGCTGATCGA", ";**9;;????")
+        record4 = Record("test", "TCGATCAGCT", ";**9;;????")
+        record5 = Record("test", "AGCTGATCGA", "????;**9;;")
+        record6 = Record("test", "AGCTGATCGA")
+        self.assertEqual(record1, record2)
+        self.assertNotEqual(record1, record3)
+        self.assertNotEqual(record1, record4)
+        self.assertNotEqual(record1, record5)
+        self.assertNotEqual(record1, record6)
+
+    def test_record_str(self):
+        self.assertEqual(str(Record("test", "AGCTGATCGA")), ">test\nAGCTGATCGA\n")
+        self.assertEqual(
+            str(Record("test", "AGCTGATCGA", ";**9;;????")),
+            "@test\nAGCTGATCGA\n+\n;**9;;????\n",
+        )
+
+    def test_record_repr(self):
+        self.assertEqual(
+            repr(Record("test", "AGCTGATCGAAGCTGATCGAA")),
+            "Record(id=test, seq=AGCTGATCGAAGCTGA…GAA, qual=None)",
+        )
+        self.assertEqual(
+            repr(Record("test", "AGCTGATCGAAGCTGATCGAA", ";**9;;????;**9;;????;")),
+            "Record(id=test, seq=AGCTGATCGAAGCTGA…GAA, qual=;**9;;????;**9;;…??;)",
+        )
+
+    def test_record_len(self):
+        self.assertEqual(len(Record("test", "AGCTGATCGA")), 10)
+
+    def test_record_hash(self):
+        record1 = Record("test", "AGCTGATCGA")
+        record2 = Record("test", "AGCTGATCGA")
+        record3 = Record("test", "AGCTGATCGA", ";**9;;????")
+        record4 = Record("test", "AGCTGATCGA", ";**9;;????")
+        record5 = Record("test", "TCGATCAGCT")
+        record6 = Record("test2", "AGCTGATCGA")
+        record7 = Record("test", "AGCTGATCGA", "????;**9;;")
+        self.assertEqual(hash(record1), hash(record2))
+        self.assertNotEqual(hash(record1), hash(record3))
+        self.assertNotEqual(hash(record1), hash(record5))
+        self.assertNotEqual(hash(record1), hash(record6))
+        self.assertNotEqual(hash(record1), hash(record3))
+        self.assertEqual(hash(record3), hash(record4))
+        self.assertNotEqual(hash(record3), hash(record7))
+
+
+class NormalizeTestCase(unittest.TestCase):
+    def test_no_normalization_needed(self):
+        self.assertEqual(normalize_seq("ACGTU", iupac=False), "ACGTT")
+
+    def test_capitalization(self):
+        self.assertEqual(normalize_seq("acgtu", iupac=False), "ACGTT")
+
+    def test_default_parameters(self):
+        self.assertEqual(
+            normalize_seq("BDHVRYSWKM"), normalize_seq("BDHVRYSWKM", iupac=False)
+        )
+
+    def test_iupac_parameter(self):
+        self.assertEqual(normalize_seq("BDHVRYSWKM", iupac=False), "NNNNNNNNNN")
+        self.assertEqual(normalize_seq("BDHVRYSWKM", iupac=True), "BDHVRYSWKM")
+        self.assertEqual(normalize_seq("bdhvryswkm", iupac=True), "BDHVRYSWKM")
+
+    def test_gap_normalization(self):
+        self.assertEqual(normalize_seq("N-N-N-N", iupac=False), "N-N-N-N")
+        self.assertEqual(normalize_seq("N.N.N.N", iupac=False), "N-N-N-N")
+        self.assertEqual(normalize_seq("N~N~N~N", iupac=False), "N-N-N-N")
+
+    def test_whitespace_removal(self):
+        self.assertEqual(normalize_seq("N N N N", iupac=False), "NNNN")
+        self.assertEqual(normalize_seq("N\tN\tN\tN", iupac=False), "NNNN")
+        self.assertEqual(normalize_seq("N\nN\nN\nN", iupac=False), "NNNN")
+        self.assertEqual(normalize_seq("N\rN\rN\rN", iupac=False), "NNNN")
+
+    def test_non_alphabet_characters(self):
+        self.assertEqual(normalize_seq("N!N!N!N", iupac=False), "NNNNNNN")
+        self.assertEqual(normalize_seq("N@N@N@N", iupac=False), "NNNNNNN")
+        self.assertEqual(normalize_seq("N#N#N#N", iupac=False), "NNNNNNN")
+        self.assertEqual(normalize_seq("N$N$N$N", iupac=False), "NNNNNNN")
+        self.assertEqual(normalize_seq("N%N%N%N", iupac=False), "NNNNNNN")
+        self.assertEqual(normalize_seq("N^N^N^N", iupac=False), "NNNNNNN")
+        self.assertEqual(normalize_seq("N&N&N&N", iupac=False), "NNNNNNN")
+        self.assertEqual(normalize_seq("N*N*N*N", iupac=False), "NNNNNNN")
+        self.assertEqual(normalize_seq("N|N|N|N", iupac=False), "NNNNNNN")
+        self.assertEqual(normalize_seq("N9N5N1N", iupac=False), "NNNNNNN")
+
+
+class ReverseComplementTestCase(unittest.TestCase):
+    def test_reverse_complement(self):
+        self.assertEqual(reverse_complement("a"), "t")
+        self.assertEqual(reverse_complement("c"), "g")
+        self.assertEqual(reverse_complement("g"), "c")
+        self.assertEqual(reverse_complement("n"), "n")
+        self.assertEqual(reverse_complement("atcg"), "cgat")
+
+
+class FileParsingTestCase(unittest.TestCase):
     def get_fasta_reader(self):
         return parse_fastx_file(FASTA_FILE)
 
@@ -20,17 +160,10 @@ class ParsingTestCase(unittest.TestCase):
                 self.assertEqual(record.id, "test")
                 self.assertEqual(record.seq, "AGCTGATCGA")
                 self.assertIsNone(record.qual)
-                record.normalize(iupac=False)
-                self.assertEqual(record.seq, "AGCTGATCGA")
-                self.assertTrue(record.is_fasta())
             if i == 1:
                 self.assertEqual(record.id, "test2")
                 self.assertEqual(record.seq, "TAGC")
                 self.assertIsNone(record.qual)
-                record.normalize(iupac=False)
-                self.assertEqual(record.seq, "TAGC")
-                self.assertTrue(record.is_fasta())
-
             self.assertTrue(i <= 1)
 
     def test_can_parse_fastq_file(self):
@@ -39,21 +172,17 @@ class ParsingTestCase(unittest.TestCase):
                 self.assertEqual(record.id, "EAS54_6_R1_2_1_413_324")
                 self.assertEqual(record.seq, "CCCTTCTTGTCTTCAGCGTTTCTCC")
                 self.assertEqual(record.qual, ";;3;;;;;;;;;;;;7;;;;;;;88")
-                record.normalize(iupac=False)
-                self.assertEqual(record.seq, "CCCTTCTTGTCTTCAGCGTTTCTCC")
-                self.assertTrue(record.is_fastq())
             if i == 1:
                 self.assertEqual(record.id, "EAS54_6_R1_2_1_540_792")
                 self.assertEqual(record.seq, "TTGGCAGGCCAAGGCCGATGGATCA")
                 self.assertEqual(record.qual, ";;;;;;;;;;;7;;;;;-;;;3;83")
-                record.normalize(iupac=False)
-                self.assertEqual(record.seq, "TTGGCAGGCCAAGGCCGATGGATCA")
-                self.assertTrue(record.is_fastq())
-
             self.assertTrue(i <= 2)
 
+    def test_pathlib_path_input(self):
+        parse_fastx_file(Path(FASTA_FILE))
 
-class ParsingStrTestCase(ParsingTestCase):
+
+class StrParsingTestCase(FileParsingTestCase):
     def get_fasta_reader(self):
         with open(FASTA_FILE) as f:
             content = f.read()
@@ -64,22 +193,8 @@ class ParsingStrTestCase(ParsingTestCase):
             content = f.read()
             return parse_fastx_string(content)
 
-
-class MiscelleanousTestCase(unittest.TestCase):
-    def test_normalize_seq(self):
-        self.assertEqual(normalize_seq("ACGTU", iupac=False), "ACGTT")
-        self.assertEqual(normalize_seq("acgtu", iupac=False), "ACGTT")
-        self.assertEqual(normalize_seq("N.N-N~N N", iupac=False), "N-N-N-NN")
-        self.assertEqual(normalize_seq("BDHVRYSWKM", iupac=True), "BDHVRYSWKM")
-        self.assertEqual(normalize_seq("bdhvryswkm", iupac=True), "BDHVRYSWKM")
-
-    def test_reverse_complement(self):
-        self.assertEqual(reverse_complement("a"), "t")
-        self.assertEqual(reverse_complement("c"), "g")
-        self.assertEqual(reverse_complement("g"), "c")
-        self.assertEqual(reverse_complement("n"), "n")
-
-        self.assertEqual(reverse_complement("atcg"), "cgat")
+    def test_pathlib_path_input(self):
+        pass
 
 
 class ErroringTestCase(unittest.TestCase):
@@ -92,5 +207,6 @@ class ErroringTestCase(unittest.TestCase):
             for i, record in enumerate(parse_fastx_string("Not a valid file")):
                 print(i)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/test_python.py
+++ b/test_python.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from needletail import (
     NeedletailError,
+    PyFastxReader,
     Record,
     normalize_seq,
     parse_fastx_file,
@@ -179,7 +180,7 @@ class FileParsingTestCase(unittest.TestCase):
             self.assertTrue(i <= 2)
 
     def test_pathlib_path_input(self):
-        parse_fastx_file(Path(FASTA_FILE))
+        self.assertIsInstance(parse_fastx_file(Path(FASTA_FILE)), PyFastxReader)
 
 
 class StrParsingTestCase(FileParsingTestCase):


### PR DESCRIPTION
This PR introduces several dunder methods to the Python `Record` class:

- `__new__`: Constructor that allows the direct creation of `Record` objects:
```py
>>> fasta_record = needletail.Record("SRR1749083.HWI-ST1309F", "NGACTCGTC")
>>> fastq_record = needletail.Record("SRR1749083.HWI-ST1309F", "NGACTCGTC", "#<<BBF/FF")
```
- `__hash__`: Returns an integer hash based on the record's ID, sequence, and quality (if available). This overrides the default `__hash__`, which generates different hashes for identical objects.
- `__eq__`: Compares two `Record` objects by checking if their IDs, sequences, and qualities (if available) are identical. While we could check for equality based on hashes, this would involve additional computation.
- `__len__`: Returns the length of the sequence, similar to BioPython's behavior.
- `__str__`: Returns a string formatted in FASTA/FASTQ style to facilitate writing FASTX files. Currently, sequences are wrapped at 60 characters for FASTA records, though the wrapping can be adjusted.
- `__repr__`: Provides a simple string representation that includes the record ID, a sequence snippet, and the quality string (when available):
```py
>>> needletail.Record("SRR1749083.HWI-ST1309F", "NGACTCGTC")
# Record(id=SRR1749083.HWI-ST1309F, sequence=NGACTCGTC, quality=None)
```
Additionally, is_fasta and is_fastq have been converted to properties.

Test coverage for these methods has not been added yet, but I will implement it if this PR is approved.