### PR TITLE
Add a `__next__` method to `PyFastxReader`

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -28,11 +28,20 @@ pub struct PyFastxReader {
 #[pymethods]
 impl PyFastxReader {
     fn __repr__(&self) -> PyResult<String> {
-        Ok("<FastxParser>".to_string())
+        Ok("<FastxReader>".to_string())
     }
 
-    fn __iter__(slf: PyRefMut<Self>, py: Python<'_>) -> PyResult<FastxReaderIterator> {
-        Ok(FastxReaderIterator { t: slf.into_py(py) })
+    fn __iter__(slf: PyRefMut<Self>) -> PyRefMut<Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<Record>> {
+        if let Some(rec) = slf.reader.next() {
+            let record = py_try!(rec);
+            Ok(Some(Record::from_sequence_record(&record)))
+        } else {
+            Ok(None)
+        }
     }
 }
 
@@ -71,24 +80,6 @@ impl Record {
             self.seq = String::from_utf8_lossy(&s).to_string();
         }
         Ok(())
-    }
-}
-
-#[pyclass]
-pub struct FastxReaderIterator {
-    t: PyObject,
-}
-
-#[pymethods]
-impl FastxReaderIterator {
-    fn __next__(slf: PyRef<Self>, py: Python<'_>) -> PyResult<Option<Record>> {
-        let mut parser: PyRefMut<PyFastxReader> = slf.t.extract(py)?;
-        if let Some(rec) = parser.reader.next() {
-            let record = py_try!(rec);
-            Ok(Some(Record::from_sequence_record(&record)))
-        } else {
-            Ok(None)
-        }
     }
 }
 


### PR DESCRIPTION
This PR adds a `__next__` method to `PyFastxReader` and merges `FastxReaderIterator` into a single class, as it was unclear to me if `FastxReaderIterator` served a purpose on its own.