### PR TITLE
Add dynamic version based on Cargo to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "needletail"
+dynamic = ["version"]
 classifier = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Fixes build. Maturin started requiring `project.dynamic` in 1.8: https://github.com/PyO3/maturin/issues/2416.

With this change, maturin will base the project version off of `Cargo.toml`.