### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,9 @@ jobs:
           maturin build --features=python --release --strip --manylinux=off
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-py${{ matrix.python-version }}
+          name: wheel-${{ matrix.runner }}-py${{ matrix.python-version }}
           path: target/wheels/*.whl
 
   upload-release:
@@ -92,7 +92,7 @@ jobs:
      runs-on: ubuntu-latest
      steps:
        - name: Download wheel artifacts
-         uses: actions/download-artifact@v3
+         uses: actions/download-artifact@v4
          with:
            path: ./wheels
 


### PR DESCRIPTION
Some of the actions were deprecated. This PR upgrades them. Also, fixed an issue where `.whl` files had overlapping names.

Tested here: https://github.com/audy/needletail/releases/tag/test-release-5