### PR TITLE
Bump version to v0.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "needletail"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Roderick Bovee <rbovee@gmail.com>", "Vincent Prouillet <vincent@onecodex.com>"]
 description = "FASTX parsing and k-mer methods"
 keywords = ["FASTA", "FASTQ", "kmer", "bioinformatics"]


### PR DESCRIPTION
This release is to just generate wheels (including the source wheel for #89) using the new build process and push them to PyPI