### PR TITLE
Update CI to build for Python 3.13 and linux-aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,12 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
+          - runner: ubuntu-22.04
+            target: aarch64
         python-version:
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -55,6 +58,7 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
           - runner: ubuntu-22.04
             target: aarch64
         python-version:
+          - "3.9"
+          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
@@ -56,6 +58,8 @@ jobs:
           - runner: macos-14
             target: aarch64
         python-version:
+          - "3.9"
+          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "needletail"
 version = "0.6.3"
-authors = ["Roderick Bovee <rbovee@gmail.com>", "Vincent Prouillet <vincent@onecodex.com>"]
+authors = [
+    "Roderick Bovee <rbovee@gmail.com>",
+    "Vincent Prouillet <vincent@onecodex.com>",
+]
 description = "FASTX parsing and k-mer methods"
 keywords = ["FASTA", "FASTQ", "kmer", "bioinformatics"]
 categories = ["science", "parsing"]
@@ -28,7 +31,7 @@ bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
 bzip2 = { version = "0.4", optional = true }
 flate2 = { version = "1.0.30", optional = true }
 memchr = "2.7.2"
-pyo3 = { version = "0.24.0", optional = true }
+pyo3 = { version = "0.24.1", optional = true }
 liblzma = { version = "0.3.1", optional = true }
 zstd = { version = "0.13.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
 bzip2 = { version = "0.4", optional = true }
 flate2 = { version = "1.0.30", optional = true }
 memchr = "2.7.2"
-pyo3 = { version = "0.21.2", optional = true }
+pyo3 = { version = "0.24.0", optional = true }
 liblzma = { version = "0.3.1", optional = true }
 zstd = { version = "0.13.2", optional = true }
 

--- a/needletail.pyi
+++ b/needletail.pyi
@@ -1,0 +1,233 @@
+from pathlib import Path
+from typing import Iterator, Union
+
+class FastxReader(Iterator[Record]):
+    """An iterator that yields sequence records.
+
+    Yields
+    ------
+    Record
+        A `Record` object representing a sequence record.
+
+    See also
+    --------
+    parse_fastx_file:
+        A function to parse sequence records from a FASTA/FASTQ file.
+    parse_fastx_string:
+        A function to parse sequence records from a FASTA/FASTQ string.
+    Record:
+        A class representing a FASTA/FASTQ sequence record.
+    """
+
+class Record:
+    """
+    A record representing a biological sequence.
+
+    Parameters
+    ----------
+    id : str
+        The identifier of the sequence record.
+    seq : str
+        A string representing the sequence.
+
+    Attributes
+    ----------
+    id : str
+        The identifier of the sequence record. In a FASTA file, this is the
+        string containing all characters (including whitespaces) after the
+        leading '>' character. In a FASTQ file, this is the string containing
+        all characters (including whitespaces) after the leading '@' character.
+    seq : str
+        A string representing the sequence.
+    qual : str, optional
+        A string representing the quality scores of the sequence. If the object
+        represents a FASTA record, this attribute will be `None`.
+    name : str
+        The name of the sequence record. This is the string before the first
+        whitespace character in the `id` attribute.
+    description : str, optional
+        The description of the sequence record. This is the string after the
+        first whitespace character in the `id` attribute. If the `id` attribute
+        contains no whitespace characters, this attribute will be `None`.
+
+    Methods
+    -------
+    is_fasta
+        Check if the object represents a FASTA record.
+    is_fastq
+        Check if the object represents a FASTQ record.
+    normalize(iupac)
+        Normalize the sequence stored in the `seq` attribute of the object.
+    """
+    def is_fasta(self) -> bool:
+        """
+        Check if the object represents a FASTA record.
+
+        Returns
+        -------
+        bool
+            `True` if the record lacks quality information, otherwise `False`.
+        """
+        pass
+
+    def is_fastq(self) -> bool:
+        """
+        Check if the object represents a FASTQ record.
+
+        Returns
+        -------
+        bool
+            `True` if the record has quality information, otherwise `False`.
+        """
+        pass
+
+    def normalize(self, iupac: bool) -> None:
+        """
+        Normalize the sequence stored in the `seq` attribute of the object.
+
+        See also
+        --------
+        normalize_seq: A function to normalize nucleotide sequence strings.
+
+        Notes
+        -----
+        The `normalize` method is designed for nucleotide sequences only. If
+        used with protein sequences, it will incorrectly process amino acid
+        characters as if they were nucleotides.
+        """
+        pass
+
+def parse_fastx_file(path: Union[str, Path]) -> FastxReader:
+    """
+    An iterator that reads sequence records from a FASTA/FASTQ file.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        The path to a FASTA/FASTQ file.
+
+    Returns
+    -------
+    FastxReader
+        A `FastxReader` iterator that yields `Record` objects representing
+        sequences from the input file.
+
+    Raises
+    ------
+    NeedletailError
+        If an error occurs while reading and parsing the input file.
+
+    See also
+    --------
+    parse_fastx_string:
+        A function to parse sequence records from a FASTA/FASTQ string.
+    FastxReader:
+        A class with instances that are iterators that yield `Record` objects.
+    """
+    pass
+
+def parse_fastx_string(fastx_string: str) -> FastxReader:
+    """
+    Parse sequence records from a FASTA/FASTQ string.
+
+    Parameters
+    ----------
+    content : str
+        A string containing FASTA/FASTQ-formatted sequence records.
+
+    Returns
+    -------
+    FastxReader
+        A `FastxReader` iterator that yields `Record` objects representing
+        sequences from the input string.
+
+    Raises
+    ------
+    NeedletailError
+        If an error occurs while parsing the input string.
+
+    See also
+    --------
+    parse_fastx_file:
+        A function to parse sequence records from a FASTA/FASTQ file.
+    FastxReader:
+        A class with instances that are iterators that yield `Record` objects.
+    """
+    pass
+
+def normalize_seq(seq: str, iupac: bool) -> str:
+    """
+    Normalize the sequence string of nucleotide records by:
+
+    - Converting lowercase characters to uppercase.
+    - Removing whitespace and newline characters.
+    - Replacing 'U' with 'T'.
+    - Replacing '.' and '~' with '-'.
+    - Replacing characters not in 'ACGTN-' with 'N', unless `iupac` is `True`,
+      in which case characters representing nucleotide ambiguity are not
+      replaced.
+
+    Parameters
+    ----------
+    seq : str
+        A string representing a nucleotide sequence.
+    iupac : bool, default: False
+        If `True`, characters representing nucleotide ambiguity ('B', 'D',
+        'H', 'V', 'R', 'Y', 'S', 'W', 'K', and 'M', and their lowercase
+        forms) will not be converted to 'N'. Lowercase characters will still
+        be converted to uppercase.
+
+    Returns
+    -------
+    str
+        The normalized sequence string.
+
+    Notes
+    -----
+    The `normalize_seq` function is designed for nucleotide sequences only. If
+    used with protein sequences, it will incorrectly process amino acid
+    characters as if they were nucleotides.
+    """
+    pass
+
+def reverse_complement(seq: str) -> str:
+    """
+    Compute the reverse complement of a nucleotide sequence.
+
+    Parameters
+    ----------
+    seq : str
+        A string representing a nucleotide sequence.
+
+    Returns
+    -------
+    str
+        The reverse complement of the input nucleotide sequence.
+
+    Notes
+    -----
+    The `reverse_complement` method is designed for nucleotide sequences
+    only. If used with protein sequences, it will incorrectly process
+    amino acid characters as if they were nucleotides.
+    """
+    pass
+
+def decode_phred(qual: str, base_64: bool) -> tuple[int]:
+    """
+    Decode Phred quality strings to quality scores.
+
+    Parameters
+    ----------
+    phred : str
+        A string representing Phred-encoded quality strings.
+    base_64 : bool, default=False
+        If `True`, return the quality using the Phred+64 encoding, otherwise
+        the Phred+33 encoding will be used.
+
+    Returns
+    -------
+    tuple of int
+        A list of integers representing quality scores derived from the
+        probability of a base-calling error using a logarithmic transformation.
+    """
+    pass

--- a/needletail.pyi
+++ b/needletail.pyi
@@ -99,7 +99,8 @@ class Record:
 
 def parse_fastx_file(path: Union[str, Path]) -> FastxReader:
     """
-    An iterator that reads sequence records from a FASTA/FASTQ file.
+    Returns an iterator that parses a FASTA/FASTQ file and yields sequence
+    records.
 
     Parameters
     ----------
@@ -128,7 +129,8 @@ def parse_fastx_file(path: Union[str, Path]) -> FastxReader:
 
 def parse_fastx_string(fastx_string: str) -> FastxReader:
     """
-    Parse sequence records from a FASTA/FASTQ string.
+    Returns an iterator that parses a FASTA/FASTQ string and yields sequence
+    records.
 
     Parameters
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [build-system]
-requires = ["maturin>=1.7,<2.0"]
+requires = ["maturin>=1.8,<2.0"]
 build-backend = "maturin"
 
 [project]
 name = "needletail"
+requires-python = ">=3.8"
 dynamic = ["version"]
 classifier = [
     "Intended Audience :: Science/Research",
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Rust",
     "License :: OSI Approved :: MIT License",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]

--- a/src/python.rs
+++ b/src/python.rs
@@ -379,12 +379,12 @@ pub fn reverse_complement(seq: &str) -> PyResult<String> {
     Ok(String::from_utf8_lossy(&comp).to_string())
 }
 
-/// Decode Phred quality data to quality scores.
+/// Decode Phred quality strings to quality scores.
 ///
 /// Parameters:
 /// -----------
 /// phred : str
-///     A string representing Phred-encoded quality data.
+///     A string representing Phred-encoded quality strings.
 /// base_64 : bool, default=False
 ///     If `True`, return the quality using the Phred+64 encoding, otherwise
 ///     the Phred+33 encoding will be used.
@@ -402,9 +402,9 @@ pub fn py_decode_phred(qual: &str, base_64: bool, py: Python<'_>) -> PyResult<Py
     } else {
         PhredEncoding::Phred33
     };
-    decode_phred(qual.as_bytes(), encoding)
-        .map(|vec| PyTuple::new_bound(py, &vec).into())
-        .map_err(|e| PyValueError::new_err(format!("Invalid Phred quality: {}", e)))
+    let scores = decode_phred(qual.as_bytes(), encoding)
+        .map_err(|e| PyValueError::new_err(format!("Invalid Phred quality: {}", e)))?;
+    Ok(PyTuple::new(py, &scores)?.into())
 }
 
 #[pymodule]

--- a/src/python.rs
+++ b/src/python.rs
@@ -264,7 +264,8 @@ impl Record {
     }
 }
 
-/// An iterator that reads sequence records from a FASTA/FASTQ file.
+/// Returns an iterator that parses a FASTA/FASTQ file and yields sequence
+/// records.
 ///
 /// Parameters
 /// ----------
@@ -297,7 +298,8 @@ fn py_parse_fastx_file(path: PathBuf) -> PyResult<PyFastxReader> {
     })
 }
 
-/// Parse sequence records from a FASTA/FASTQ string.
+/// Returns an iterator that parses a FASTA/FASTQ string and yields sequence
+/// records.
 ///
 /// Parameters
 /// ----------


### PR DESCRIPTION
This PR:  

- Updates the CI to include builds for Python 3.9, 3.10, 3.13, and linux-aarch64.  
- Updates the code for compatibility with PyO3 0.24, incorporating support for free-threaded Python by [using locks](https://pyo3.rs/v0.24.0/class/thread-safety#using-locks) in `FastxReader`.
- Exposes `PyFastxReader` as `FastxReader` in the Python module.
- Adds a [stub file](https://pyo3.rs/main/python-typing-hints.html) to enable IDE type hinting and docstring display upon hovering.