### PR TITLE
Add Phred decoding functionality

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -160,3 +160,22 @@ impl StdError for ParseError {
         None
     }
 }
+
+/// Represents an error during decoding of FASTQ quality data
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PhredOffsetError {
+    /// Quality value that failed to convert
+    pub q: u8,
+    /// Offset used to convert to the target encoding
+    pub offset: u8,
+}
+
+impl fmt::Display for PhredOffsetError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "quality value '{}' cannot be decoded with offset '{}'",
+            self.q, self.offset
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ extern crate pyo3;
 pub mod bitkmer;
 pub mod kmer;
 pub mod parser;
+pub mod quality;
 pub mod sequence;
 
 pub mod errors;

--- a/src/parser/record.rs
+++ b/src/parser/record.rs
@@ -104,7 +104,7 @@ impl<'a> SequenceRecord<'a> {
     /// Decodes Phred quality data to quality scores. See documentation for
     /// `needletail::quality::decode_phred`. This returns a `Result` containing
     /// an `Option<Cow<'a, [u8]>>` of the decoded quality scores, which may be
-    /// coerced to a `Vec<u8>` or `&[u8]`. In case the Phred quality data is
+    /// coerced to `Vec<u8>` or `&[u8]`. In case the Phred quality data is
     /// incompatible with the specified source encoding, an error is returned.
     pub fn decode_phred(
         &self,
@@ -250,7 +250,7 @@ pub fn write_fastq(
 mod test {
     use std::io::Cursor;
 
-    use crate::parse_fastx_reader;
+    use crate::{parse_fastx_reader, quality::PhredEncoding};
     fn seq(s: &[u8]) -> Cursor<&[u8]> {
         Cursor::new(s)
     }
@@ -282,5 +282,13 @@ mod test {
 
         let rec = reader.next().unwrap().unwrap();
         assert_eq!(rec.position().byte(), 40);
+    }
+
+    #[test]
+    fn test_record_decode_phred() {
+        let mut reader = parse_fastx_reader(seq(b"@test1\nACGT\n+\nIIII")).unwrap();
+        let rec = reader.next().unwrap().unwrap();
+        let decoded_qual = rec.decode_phred(PhredEncoding::Phred33).unwrap().unwrap();
+        assert_eq!(decoded_qual.as_ref(), &[40, 40, 40, 40]);
     }
 }

--- a/src/quality.rs
+++ b/src/quality.rs
@@ -1,0 +1,65 @@
+use crate::errors::PhredOffsetError;
+
+/// Encoding for quality scores
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PhredEncoding {
+    Phred33,
+    Phred64,
+}
+
+/// Decodes Phred quality data to quality scores. Each character is decoded
+/// by subtracting the offset corresponding to the specified source encoding
+/// (PhredEncoding::Phred33 for Phred+33, or PhredEncoding::Phred64 for Phred+64).
+/// If the ASCII value of the character is less than the offset, `PhredOffsetError`
+/// is returned.
+pub fn decode_phred(qual: &[u8], encoding: PhredEncoding) -> Result<Vec<u8>, PhredOffsetError> {
+    let offset = match encoding {
+        PhredEncoding::Phred33 => b'!',
+        PhredEncoding::Phred64 => b'@',
+    };
+    let mut scores = Vec::with_capacity(qual.len());
+    for &q in qual {
+        if q < offset {
+            return Err(PhredOffsetError { q, offset });
+        }
+        scores.push(q - offset);
+    }
+    Ok(scores)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_decode_phred33() {
+        assert_eq!(
+            decode_phred(b"#</</BBFFFBF<", PhredEncoding::Phred33),
+            Ok(vec![2, 27, 14, 27, 14, 33, 33, 37, 37, 37, 33, 37, 27])
+        );
+    }
+
+    #[test]
+    fn test_decode_phred64() {
+        assert_eq!(
+            decode_phred(b"B[N[Naaeeeae[", PhredEncoding::Phred64),
+            Ok(vec![2, 27, 14, 27, 14, 33, 33, 37, 37, 37, 33, 37, 27])
+        );
+    }
+
+    #[test]
+    fn test_decode_phred33_error() {
+        assert_eq!(
+            decode_phred(b"#</</BBFFFBF ", PhredEncoding::Phred33),
+            Err(PhredOffsetError { q: 32, offset: 33 })
+        );
+    }
+
+    #[test]
+    fn test_decode_phred64_error() {
+        assert_eq!(
+            decode_phred(b"B[N[Naaeeeae?", PhredEncoding::Phred64),
+            Err(PhredOffsetError { q: 63, offset: 64 })
+        );
+    }
+}


### PR DESCRIPTION
This PR adds Phred decoding functionality to `needletail`. The following changes are introduced:

- **`quality` module:**
  - Adds a new `quality` module.
  - Adds the `PhredEncoding` enum, representing the type of encoding (Phred+33 or Phred+64).
  - Includes the `decode_phred` function, which takes Phred-encoded quality data (`&[u8]`) and a `PhredEncoding` instance, returning the decoded quality scores.
- **`errors` module:**
  - Adds the `PhredOffsetError` struct, representing a Phred-decoding error where the offset (33 or 64, depending on the encoding) exceeds the encoded quality value.
- **`SequenceRecord`:**
  - Adds a `decode_phred` method that returns a `Option` containing the decoded quality scores of FASTQ records. Decoded data is returned as a `Cow<'a, [u8]>`, which may be coerced to `Vec<u8>` or `&[u8]`.

Tests are included for both to the `quality::decode_phred` function and `record::SequenceRecord::decode_phred`.

The motivation for this PR is to use the added functions in the following PR: https://github.com/onecodex/needletail/pull/98