### PR TITLE
Fix PyPI release glob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,4 +130,4 @@ jobs:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
-          args: --non-interactive --skip-existing wheels-*/**
+          args: --non-interactive --skip-existing wheels-*/**.whl wheels-*/**.tar.gz


### PR DESCRIPTION
Fixes file pattern glob in the release action which is [causing an error](https://github.com/onecodex/needletail/actions/runs/13445317076/job/37569261118). I made the same change in https://github.com/onecodex/taxonomy which has been tested.