### PR TITLE
Include `Record`'s attributes in the stub file

### DIFF
--- a/needletail.pyi
+++ b/needletail.pyi
@@ -1,8 +1,9 @@
 from pathlib import Path
-from typing import Iterator, Union
+from typing import Iterator, Optional, Union
 
 class FastxReader(Iterator[Record]):
-    """An iterator that yields sequence records.
+    """
+    An iterator that yields sequence records.
 
     Yields
     ------
@@ -59,6 +60,11 @@ class Record:
     normalize(iupac)
         Normalize the sequence stored in the `seq` attribute of the object.
     """
+
+    id: str
+    seq: str
+    qual: Optional[str]
+
     def is_fasta(self) -> bool:
         """
         Check if the object represents a FASTA record.

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,6 +1,7 @@
 //! Python bindings for needletail
 
 // TODO:
+// - Enable reading FASTA and FASTQ files from stdin
 // - The `normalize` method of the `Record` class should return a new `Record`
 //   object with the normalized sequence.
 // - Add a `reverse_complement` method to the `Record` class that returns a new


### PR DESCRIPTION
This is a minor PR. It adds the `id`, `seq`, and `qual` attributes of the `Record` class to the stub file.