### PR TITLE
Bump bzip2 to 0.6 for new rust backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ xz2 = ["liblzma"]
 [dependencies]
 buffer-redux = { version = "1", default-features = false }
 bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
-bzip2 = { version = "0.4", optional = true }
+bzip2 = { version = "0.6", optional = true }
 flate2 = { version = "1.0.30", optional = true }
 memchr = "2.7.2"
 pyo3 = { version = "0.27.2", optional = true }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,7 +23,6 @@ impl fmt::Display for ErrorPosition {
     }
 }
 
-
 /// The type of error that occurred during file parsing
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ParseErrorKind {


### PR DESCRIPTION
I ran into some [issues](https://github.com/ronnychevalier/cargo-multivers/issues/24) trying to run a binary compiled on my laptop on a server, and it turns out that this is because the server is missing the `libbz2.so.1.0` file that is dynamically linked against.

The current [bzip2](https://github.com/trifectatechfoundation/bzip2-rs) `0.4` dependency tries to dynamically link against `bz2`, and falls back to building from source.
One fix would be to simply add the `static` feature (possibly only enabled via some feature like `static-bzip2` on `needletail`), but the simpler fix is probably to just bump it to the current 0.6 as I did here, since it now uses the [rust backend](https://crates.io/crates/libbz2-rs-sys) by default, which should just fix all these issues completely.

Note that some other crates/compression backends also have breaking updates, but it may not be desirable to bump those, because eg linking to `lib-zma` `0.3.13` and `0.4.5` at the same time is impossible.
This is not an issue for `bzip2`, because the new version does not link against anything anymore.