### PR TITLE
Bump toml from 0.8 to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ seq_io = "0.3"
 # for testing with the FormatSpecimens.jl repo samples
 serde = "1.0"
 serde_derive = "1.0"
-toml = "0.8"
+toml = "0.9"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Bumps `toml` from `0.8` to `0.9` (stable since 2025-08-29).

The two call sites are in `tests/format_specimens.rs`, both using `toml::from_str`. That API is stable across 0.8 and 0.9, so no source changes are required.

### Verification

* `cargo build`: clean
* `cargo test`: 9 passed, 0 failed
* `cargo clippy --all-targets -- -D warnings`: clean
* `cargo fmt --all --check`: clean

### Context

Part of the Debian Rust team's `toml 0.9` transition (debcargo-conf#147). needletail is one of the reverse-dependencies currently on 0.8.
