### PR TITLE
Bump pyo3 verison to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
 bzip2 = { version = "0.6", optional = true }
 flate2 = { version = "1.0.30", optional = true }
 memchr = "2.7.2"
-pyo3 = { version = "0.27.2", optional = true }
+pyo3 = { version = "0.29.0", optional = true }
 liblzma = { version = "0.3.1", optional = true }
 zstd = { version = "0.13.2", optional = true }
 


### PR DESCRIPTION
This PR bumps the `pyo3` version to `0.29`.